### PR TITLE
use bespoke limo_base from westonrobot

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base_image: lcas.lincoln.ac.uk/lcas/ros-docker-images:jammy-cuda11.8-humble-2
+          - base_image: lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2
   
     steps:
     - name: Node Js


### PR DESCRIPTION
This pull request includes a small update to the Docker build workflow configuration. The change updates the base image used in the matrix of jobs.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L24-R24): Changed the base image from `lcas.lincoln.ac.uk/lcas/ros-docker-images:jammy-cuda11.8-humble-2` to `lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2`.