### PR TITLE
Trials on limo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,8 @@
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {
-			// set the base image, add `-arm64` as a suffix if you have an ARM (e.g. Apple Mx) CPU:
-			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl-1.1"
+			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2"
 		},
-		// change this to linux/arm64 if you have an ARM (e.g. Apple Mx) CPU:
-		"platform": "linux/amd64",
 		"context": ".."
 	},
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Using the Docker image for the real robot
 
+## Requirements
+
+* an environment variable `ROBOT_NAME` is expected to be defined, either in `.env` or in the environment (e.g. `~/.bashrc`)
+* Docker is needed with the NIVIDA runtime running and tested
+
+
 ### Starting the Container
 
 1. Navigate to the `configs` directory of this repository:
@@ -25,3 +31,6 @@ docker compose up -d && docker compose logs -f
 ### Stopping the container
 
 1. `docker compose down`, again in the `configs` directory
+
+
+## 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# limo_platform
-The AgileX LIMO robot platform
+# A containerised, clean ROS2 workspace for the AgileX Limo Platform
+
+## Using the Docker image for the real robot
+
+### Starting the Container
+
+1. Navigate to the `configs` directory of this repository:
+```bash
+cd configs
+```
+
+2. Start the container in detached mode and view logs:
+```bash
+docker compose up -d && docker compose logs -f
+```
+
+*Note:* By default, the containers here are restarted at boot time
+
+### Accessing the virtual desktop
+
+1. Find the IP address of your robot, let's name it `LIMO_IP`
+2. Open your browser at address http://`LIMO_IP`:5801/, and connect
+
+
+### Stopping the container
+
+1. `docker compose down`, again in the `configs` directory

--- a/configs/docker-compose.yaml
+++ b/configs/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     - ROS_DISTRO=humble
 
   limo_drivers:
-    image: lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2
+    image: lcas.lincoln.ac.uk/lcas/limo_platform:2
             #lcas.lincoln.ac.uk/lcas/limo_platform:staging
 
     user: "ros"
@@ -35,15 +35,17 @@ services:
     hostname: "${ROBOT_NAME}"
     # nned privileged mode to access the camera and hardware
     privileged: true
-    command: bash -c "while true; do sleep 10; done"
+    ipc: host
+    #command: bash -c "while true; do sleep 10; done"
     #command: bash -c "zenoh-bridge-ros2dds -r 8080 -l tcp/0.0.0.0:8888"
-    #command: bash -c "source /opt/ros/lcas/install/setup.bash; echo $$CYCLONEDDS_URI; (ros2 launch astra_camera dabai.launch.py &); ros2 launch limo_bringup limo_start.launch.py"
+    command: bash -c "source /opt/ros/lcas/install/setup.bash; echo $$CYCLONEDDS_URI; (ros2 launch astra_camera dabai.launch.py &); ros2 launch limo_bringup limo_start.launch.py"
     volumes:
-      # - /dev:/dev
+      - /dev:/dev
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     runtime: nvidia
     restart: unless-stopped
+    shm_size: '2gb' 
     environment:
       # always use virtual desktop
       - DISPLAY:1

--- a/configs/docker-compose.yaml
+++ b/configs/docker-compose.yaml
@@ -1,0 +1,114 @@
+version: '3'
+services:
+  zenoh_router: 
+    image: eclipse/zenoh-bridge-ros2dds:latest
+    restart: "unless-stopped"
+    networks:
+      - rosnet
+    # expose REST API, and Zenoh API
+    ports:
+      - 7447:7447
+      - 8000:8000
+    
+    # start the Zenoh router to allow remote access on port 8888
+    # also allows REST API access via Zenoh on port 8080
+    command: "-r 8000 -l tcp/0.0.0.0:7447 router"
+    links:
+      - limo_drivers
+
+    # need to set ROS_DISTRO to the correct version for the bridge to work correctly
+    environment:
+    - ROS_DISTRO=humble
+
+  limo_drivers:
+    image: lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2
+            #lcas.lincoln.ac.uk/lcas/limo_platform:staging
+
+    user: "ros"
+
+    # expose desktop access
+    ports:
+      - 5801:5801
+      - 5901:5901
+    
+    # NOTE: We expect the environment varibable ROBOT_NAME to be set, e.g. in `.env`
+    hostname: "${ROBOT_NAME}"
+    # nned privileged mode to access the camera and hardware
+    privileged: true
+    command: bash -c "while true; do sleep 10; done"
+    #command: bash -c "zenoh-bridge-ros2dds -r 8080 -l tcp/0.0.0.0:8888"
+    #command: bash -c "source /opt/ros/lcas/install/setup.bash; echo $$CYCLONEDDS_URI; (ros2 launch astra_camera dabai.launch.py &); ros2 launch limo_bringup limo_start.launch.py"
+    volumes:
+      # - /dev:/dev
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    runtime: nvidia
+    restart: unless-stopped
+    environment:
+      # always use virtual desktop
+      - DISPLAY:1
+      - ROS_LOCALHOST_ONLY=0
+
+      # - >
+      #   CYCLONEDDS_URI=
+      #   <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+      #     <Domain id="0">
+      #       <General>
+      #         <AllowMulticast>true</AllowMulticast>
+      #         <MaxMessageSize>65500B</MaxMessageSize>
+      #         <FragmentSize>4000B</FragmentSize> 
+      #         <Transport>udp</Transport>
+      #         <Interfaces>
+      #             <NetworkInterface name="eth0"/>
+      #         </Interfaces>
+      #       </General>
+      #       <Discovery>
+      #         <Peers>
+      #           <!--<Peer address="limo_drivers"/>-->
+      #           <!--<Peer address="LIMO-1522"/>-->
+      #           <!--<Peer address="[IPV6-address]"/>--> 
+      #         </Peers>
+      #         <ParticipantIndex>auto</ParticipantIndex>
+      #         <MaxAutoParticipantIndex>100</MaxAutoParticipantIndex>
+      #       </Discovery>
+      #       <Internal>
+      #         <Watermarks>
+      #           <WhcHigh>500kB</WhcHigh>
+      #         </Watermarks>
+      #       </Internal>
+      #       <Tracing>
+      #         <Verbosity>info</Verbosity>
+      #         <OutputFile>stderr</OutputFile>
+      #       </Tracing>
+      #     </Domain>
+      #   </CycloneDDS>
+      # - 'LIBGL_ALWAYS_SOFTWARE=1'
+      # - 'ROS_DOMAIN_ID=0'
+      # - 'NVIDIA_VISIBLE_DEVICES=all'
+    #network_mode: host
+    networks:
+      - rosnet
+    cap_add:
+        - NET_ADMIN
+        - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+
+networks:
+  rosnet:
+    driver: bridge
+    ipam:
+     driver: default
+     config:
+       - subnet: 172.100.0.0/16
+    driver_opts:
+      com.docker.network.container_iface_prefix: eth


### PR DESCRIPTION
This pull request includes significant updates to the Docker configuration and documentation for the AgileX Limo Platform. The changes introduce a new Docker image, update the `README.md` with detailed instructions, and add a `docker-compose.yaml` file to manage services.

Updates to Docker configuration and documentation:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L11-L15): Updated the `BASE_IMAGE` to `lcas.lincoln.ac.uk/lcas/ros-docker-images:westonrobot-humble-2` and removed the platform specification.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R27): Revised the introduction and added detailed instructions for using the Docker image with the real robot, including starting and stopping the container and accessing the virtual desktop.

Addition of Docker Compose configuration:

* [`configs/docker-compose.yaml`](diffhunk://#diff-84132d00546ea095121762d3060e9c5e42821fc9496f8b96fb928a55f2402265R1-R116): Added a new Docker Compose configuration file to set up services for `zenoh_router` and `limo_drivers`, including network settings, environment variables, and resource reservations.